### PR TITLE
Disable some cops from Maji's .rubocop_todo.yml

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -13,52 +13,38 @@ Bundler/OrderedGems:
   Exclude:
     - "Gemfile"
 
-BracesAroundHashParameters:
-  Enabled: false
-
-CaseIndentation:
-  Enabled: false
-
-ClassLength:
+Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
 Metrics/AbcSize:
   Enabled: false
 
-Style/GuardClause:
-  Exclude:
-    - "spec/**/*"
-
-RescueModifier:
-  Exclude:
-    - "spec/**/*"
-
-Style/RegexpLiteral:
+Metrics/BlockLength:
   Enabled: false
 
-Style/Documentation:
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
   Enabled: false
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
-Metrics/MethodLength:
+Metrics/PerceivedComplexity:
   Enabled: false
 
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodDefParentheses:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
-
 Rails:
   Enabled: true
 
-Rails/TimeZone:
-  EnforcedStyle: 'flexible'
+Rails/ApplicationRecord:
+  Enabled: true
 
 Rails/Date:
   EnforcedStyle: 'flexible'
@@ -67,32 +53,47 @@ Rails/Output:
   Exclude:
     - "lib/tasks/*"
 
+Rails/TimeZone:
+  EnforcedStyle: 'flexible'
+
 RSpec/Focused:
   Enabled: true
 
-Layout/MultilineMethodCallBraceLayout:
+Style/BracesAroundHashParameters:
   Enabled: false
 
-Metrics/BlockLength:
+Style/CaseIndentation:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
+Style/Documentation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GuardClause:
+  Exclude:
+    - "spec/**/*"
+
+Style/MethodDefParentheses:
+  Enabled: false
+
 Style/PercentLiteralDelimiters:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: 'comma'
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/RescueModifier:
+  Exclude:
+    - "spec/**/*"
+
+Style/SignalException:
+  Enabled: false
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'
 
-Rails/ApplicationRecord:
-  Enabled: true
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: 'comma'
+

--- a/default.yml
+++ b/default.yml
@@ -9,6 +9,10 @@ AllCops:
   Exclude:
     - '*.gemspec'
 
+Bundler/OrderedGems:
+  Exclude:
+    - "Gemfile"
+
 BracesAroundHashParameters:
   Enabled: false
 

--- a/default.yml
+++ b/default.yml
@@ -66,6 +66,12 @@ Rails/Output:
 RSpec/Focused:
   Enabled: true
 
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: false
 
@@ -73,6 +79,9 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
   Enabled: false
 
 Style/TrailingCommaInLiteral:

--- a/lib/charity_water/style/version.rb
+++ b/lib/charity_water/style/version.rb
@@ -1,5 +1,5 @@
 module CharityWater
   module Style
-    VERSION = '1.0'.freeze
+    VERSION = '1.1'.freeze
   end
 end


### PR DESCRIPTION
This just disables a handful of cops that had lots of violations in Maji & were disabled in the .rubocop-todo.yml file - only disabling them here now because I'm running into violations over in SNSS and I'd rather ignore them here than in SNSS's configuration.

[#152692963](https://www.pivotaltracker.com/story/show/152692963)