### PR TITLE
Add thread thread safety rubocop rules.

### DIFF
--- a/cw-style.gemspec
+++ b/cw-style.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rubocop", "= 0.49.1"
   spec.add_dependency "rubocop-rspec-focused", "= 0.0.3"
+  spec.add_dependency "rubocop-thread_safety"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"

--- a/default.yml
+++ b/default.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop/rspec/focused
+  - rubocop-thread_safety
   - ./lib/unless_with_multiple_conditions
   - ./lib/private_attribute_accessors
   - ./lib/update_not_update_attributes

--- a/lib/charity_water/style/version.rb
+++ b/lib/charity_water/style/version.rb
@@ -1,5 +1,5 @@
 module CharityWater
   module Style
-    VERSION = '1.2'.freeze
+    VERSION = '2.0'.freeze
   end
 end


### PR DESCRIPTION
I tested this locally in maji by making this change in maji and `bundle install`ing:

```ruby
# gem 'cw-style', source: 'https://repo.fury.io/KKkJFKCWQHA2sz571Bud/me/' # shared rubocop configuration for all c: w apps
gem 'cw-style', path: '/Users/jasdeepgosal/src/cw-style' # shared rubocop configuration for all c: w apps
```

Then running `bundle exec rubocop`:

```bash
~/src/maji (x-investigate-thread-safety-of-157217722) $ be rubocop
Inspecting 1389 files
..........................................................................................................................................................................................................................................................C.....................................................................................................................................................................................................C................................................................................................................................................................................................................................................................................................................................................................................................C...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Offenses:

app/models/user.rb:75:5: C: Avoid instance variables in class methods.
    @system_user ||= for_email('sysadmin@charitywater.org').take
    ^^^^^^^^^^^^
app/models/user.rb:80:5: C: Avoid instance variables in class methods.
    @system_user = nil
    ^^^^^^^^^^^^
lib/cw_contentful/client_provider.rb:7:9: C: Avoid instance variables in class methods.
        @client ||= Contentful::Client.new(
        ^^^^^^^
spec/features/donations/to_system_campaigns_spec.rb:10:5: C: Avoid instance variables in class methods.
    @active_system_campaigns ||=
    ^^^^^^^^^^^^^^^^^^^^^^^^

1389 files inspected, 4 offenses detected
```

[#157217722](https://www.pivotaltracker.com/story/show/157217722)