### PR TITLE
Update trailing comma cops per Rubocop error

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -95,6 +95,8 @@ Style/SignalException:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: 'comma'
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: 'comma'
 
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: 'comma'

--- a/lib/charity_water/style/version.rb
+++ b/lib/charity_water/style/version.rb
@@ -1,5 +1,5 @@
 module CharityWater
   module Style
-    VERSION = '2.0'.freeze
+    VERSION = '2.1'.freeze
   end
 end


### PR DESCRIPTION
An error was preventing me from using Rubocop in maji:

```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```

Fix the error.