### PR TITLE
Update cop for new RuboCop versions

### DIFF
--- a/lib/charity_water/style/version.rb
+++ b/lib/charity_water/style/version.rb
@@ -1,5 +1,5 @@
 module CharityWater
   module Style
-    VERSION = '2.1.1'.freeze
+    VERSION = '2.2.0'.freeze
   end
 end

--- a/lib/private_attribute_accessors.rb
+++ b/lib/private_attribute_accessors.rb
@@ -21,13 +21,14 @@ module RuboCop
           return [] unless body
 
           private_nodes(body).select do |node|
-            %i(attr_reader attr_writer attr_accessor).include?(node.method_name)
+            node.send_type? && %i(attr_reader attr_writer attr_accessor).include?(node.method_name)
           end
         end
 
         def private_nodes(body)
-          index = body.child_nodes.index { |x| x.method_name == :private }
+          index = body.child_nodes.index { |x| x.send_type? && x.access_modifier? && x.method_name == :private }
           return [] unless index
+
           body.child_nodes[(index + 1)..-1]
         end
       end

--- a/spec/private_attribute_accessors_spec.rb
+++ b/spec/private_attribute_accessors_spec.rb
@@ -57,6 +57,25 @@ describe RuboCop::Cop::Style::PrivateAttributeAccessors do
               'Do not use private attribute accessors'])
   end
 
+  it 'can handle non-access modifier node types' do
+    inspect_source cop, <<-RUBY.strip_indent
+        class AwesomeController < RighteousController
+          def create
+            case variable_name
+            when 'something'
+              OtherClass::WorkerClass.perform_async argument
+            when 'something else'
+              OtherClass::WorkerClass.perform_async argument
+            end
+
+            head :ok
+          end
+        end
+    RUBY
+
+    expect(cop.offenses.size).to eq(0)
+  end
+
   it 'isn\'t offend by using any attr_* methods in public scope' do
     inspect_source cop, <<-RUBY.strip_indent
         class SmallThing < Thing


### PR DESCRIPTION
The `PrivateAttributeAccessors` cop was having issues with newer versions of RuboCop, which must be sending more and/or different nodes along to the `on_class` method of cops than it previously did. These changes perform additional checks on nodes before looking for their `method_name` to avoid `NoMethodError`s. The logic was in part ganked from RuboCop's `UselessAccessModifier` cop.

It also bumps the version.