### PR TITLE
Upgrade Rubocop

### DIFF
--- a/cw-style.gemspec
+++ b/cw-style.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.74.0"
+  spec.add_dependency "rubocop", ">= 0.84.0"
   spec.add_dependency "rubocop-rspec-focused", "= 0.0.3"
   spec.add_dependency "rubocop-thread_safety"
   spec.add_dependency "rubocop-rails"

--- a/cw-style.gemspec
+++ b/cw-style.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-rspec-focused", "= 0.0.3"
   spec.add_dependency "rubocop-thread_safety"
   spec.add_dependency "rubocop-rails"
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "debugger-ruby_core_source"

--- a/default.yml
+++ b/default.yml
@@ -21,6 +21,36 @@ Layout/CaseIndentation:
 Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: False # disabled until autocorrectable in 0.87
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -42,7 +72,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Rails:
@@ -63,9 +93,6 @@ Rails/TimeZone:
 
 RSpec/Focused:
   Enabled: true
-
-Style/BracesAroundHashParameters:
-  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/lib/charity_water/style/version.rb
+++ b/lib/charity_water/style/version.rb
@@ -1,5 +1,5 @@
 module CharityWater
   module Style
-    VERSION = '3.0.0'.freeze
+    VERSION = '4.0.0'.freeze
   end
 end

--- a/spec/private_attribute_accessors_spec.rb
+++ b/spec/private_attribute_accessors_spec.rb
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::PrivateAttributeAccessors do
   end
 
   it 'registers an offense for using any attr_* methods in private scope' do
-    inspect_source cop, <<-RUBY.strip_indent
+    inspect_source cop, <<~RUBY
         class SmallThing < Thing
         private
           attr_reader :anything
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Style::PrivateAttributeAccessors do
   end
 
   it 'can handle non-access modifier node types' do
-    inspect_source cop, <<-RUBY.strip_indent
+    inspect_source cop, <<~RUBY
         class AwesomeController < RighteousController
           def create
             case variable_name
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Style::PrivateAttributeAccessors do
   end
 
   it 'isn\'t offend by using any attr_* methods in public scope' do
-    inspect_source cop, <<-RUBY.strip_indent
+    inspect_source cop, <<~RUBY
         class SmallThing < Thing
           attr_reader :anything
           attr_writer :something


### PR DESCRIPTION
Since version ~0.80, rubocop now warns you about new rules and you have to explicitly enable or disable them. 

I reviewed each of these rules and decided to keep them, primarily because I either liked what the rule did or it was trivial, autocorrectable, and I trust the rubocop/rails community. I’m open to changing any of the rules if they prove problematic. 

Docs: https://docs.rubocop.org/rubocop/0.85/versioning.html#pending-cops

I tried upgrading to the latest version (0.86), but that resulted in some gem version conflicts that would’ve required upgrading capyabara, which I already decided I don’t want to deal with yet: https://github.com/charitywater/maji/pull/9460/commits/dd9d67ea89bfffcc93da97c012aee8c1ff69f389

BracesAroundHashParameters was removed: https://github.com/rubocop-hq/rubocop/issues/7641

[#172410772]